### PR TITLE
Updating subprocess call

### DIFF
--- a/kstar_planner/planners.py
+++ b/kstar_planner/planners.py
@@ -18,7 +18,7 @@ def run_planner(planner_args) -> dict:
         with tempfile.NamedTemporaryFile() as result_file:
 
             args_json_name = [a.replace("PLANS_JSON_NAME", str(result_file.name)) for a in planner_args]
-            subprocess.run([sys.executable, "-B", "-m", "driver.main"] + default_build_args + args_json_name, 
+            subprocess.run([sys.executable, "-B", "-m", "kstar_planner.driver.main"] + default_build_args + args_json_name, 
                            stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT)
 
             with open(str(result_file.name)) as plans_file:


### PR DESCRIPTION
Upon installing the package with pip, the driver module is located inside the kstar_planner module. Hence updating the subprocess call.

Fix for Issue #4 .
